### PR TITLE
feat: support multiple instance identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Before you can start using the catalog manager, you must add some configuration 
 
 The `directory` key specifies where the translations catalogs will be stored. It is optional and defaults to `l10n`.
 
-The `instance` key specifies the variable name of your instance of the `L10n` class. It is optional and defaults to `l10n`. It can also reflect a deeper structure suche as `this.l10n` or `some.object.l10n`.
+The `instance` key specifies the variable name of your instance of the `L10n` class. It is optional and defaults to `l10n`. It can also reflect a deeper structure suche as `this.l10n`, `some.object.l10n` or even multiple values like `["this.l10n", "some.object.l10n"]`.
 
 The `locales` key specifies the locales into which your package should be translated. The format for locales is: two lowercase letters for the language, followed by a hyphen (not an underscore!), followed by two uppercase letters for the region/country. NOTE: This tool assumes the `en-GB` locale as default, therefore you don’t need to add it.
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -31,7 +31,7 @@ export function getConfig() {
     }
 
     config.directory = config.directory || "l10n"
-    config.instance = config.instance || "l10n"
+    config.instance = Array.isArray(config.instance) ? config.instance : [config.instance || "l10n"]
 
     return config
 }

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -8,10 +8,10 @@ import * as htmlparser from 'node-html-parser'
 /**
  * extracts translatable strings from JavaScript files
  * @param string[] globs list of glob expressions
- * @param string _instanceName name of the L10n instance ("l10n" by default)
+ * @param string[] _instanceNames name of the L10n instance ("l10n" by default)
  * @return object[] list of found entries
  */
-export default function(globs, instanceName) {
+export default function(globs, instanceNames) {
     const cwd = getProjectRootDir()
     const entries = []
 
@@ -26,9 +26,9 @@ export default function(globs, instanceName) {
             // and might change significantly with upcoming versions.
 
             if (fileName.endsWith(".html"))
-                entries.push(...getEntriesFromHtml(relName, file.toString(), instanceName))
+                entries.push(...getEntriesFromHtml(relName, file.toString(), instanceNames))
             else
-                entries.push(...getEntriesFromJs(relName, file, instanceName))
+                entries.push(...getEntriesFromJs(relName, file, instanceNames))
         })
     })
 
@@ -56,14 +56,14 @@ function getEntriesFromHtml(fileName, file) {
     return entries
 }
 
-function getEntriesFromJs(fileName, file, instanceName) {
+function getEntriesFromJs(fileName, file, instanceNames) {
     const entries = []
     const ast = acorn.LooseParser.parse(file, { sourceType : "module", locations : true })
 
     walk.full(ast, node => {
         if (node.type === "CallExpression"
             && node.callee.type === "MemberExpression"
-            && instanceName === getInstanceName(node.callee))
+            && instanceNames.includes(getInstanceName(node.callee)))
         {
             const position = node.callee.loc.start
 

--- a/lib/schema.json
+++ b/lib/schema.json
@@ -8,6 +8,11 @@
             "items": {
                 "type": "string"
             }
+        },
+        "instance": {
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 100
         }
     },
 
@@ -19,9 +24,17 @@
             "maxLength": 100
         },
         "instance": {
-            "type": "string",
-            "minLength": 2,
-            "maxLength": 100
+            "oneOf": [
+                {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/_definitions/instance"
+                    }
+                },
+                {
+                    "$ref": "#/_definitions/instance"
+                }
+            ]
         },
         "locales": {
             "type": "array",


### PR DESCRIPTION
Hi @lxg,
This PR provides the ability to provide multiple instance tokens to search for in the code.
Use case for this is to example use `l10n` as a class member (ex in web-components) and in functions directly in one repository:
```
class A {
  private locale;
  private l10n;

  componentWillLoad() {
    this.l10n = new L10n(translations, this.locale);
  }

  someMethod() {
    const message = this.l10n.t('my message')
  }
}

...

someUtilityMethod(l10n) {
  const message = l10n.t('my message')
}
```

For this i would need to provide config like this:
```
"instance": ["this.l10n", "l10n"],
```

Let me know if that is something that could be integrated.